### PR TITLE
Remove left-margin on the span12 hero on single posts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -296,6 +296,9 @@ a:hover {
     max-width: 90%;
   }
 }
+.single .hero.span12 {
+  margin-left: 0;
+}
 .gform_wrapper.donation_form_wrapper .gfield_required,
 .gform_wrapper.membership_form_wrapper .gfield_required,
 .gform_wrapper.donation_form_wrapper .ginput_product_price_label,

--- a/less/common.less
+++ b/less/common.less
@@ -271,3 +271,6 @@ a {
       max-width: 90%;
   }
 }
+.single .hero.span12 {
+  margin-left: 0;
+}


### PR DESCRIPTION
A fix for https://github.com/INN/largo/issues/1401 in the INN main theme: fixes left-margin on a `width: 100%;` element causing the page to have an offcenter layout. Example post: https://inn.org/2017/05/inn-days-2017/

After merging this into the INN theme, we'll need to recompile LESS files for all child themes in the umbrella-inndev repo, as most include LESS files from this theme: https://github.com/INN/umbrella-inndev/tree/master/wp-content/themes