### PR TITLE
styles and partial for news match campaign

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -528,10 +528,23 @@ a:hover {
   margin-left: 0;
 }
 .alert {
-  padding: 3px 2.5%;
-  background-color: #df4646;
-  width: 95%;
+  border-bottom: 10px solid #33BF95;
+  background-color: #fff;
+  padding-top: 10px;
   clear: both;
+}
+.alert .img {
+  margin: .75em 0 15px 0;
+}
+@media (max-width: 768px) {
+  .alert {
+    text-align: center;
+    padding: 1em 2.5%;
+  }
+  .alert .img {
+    display: block;
+    margin: 0 auto;
+  }
 }
 .alert p {
   margin-bottom: 0;

--- a/css/style.css
+++ b/css/style.css
@@ -530,7 +530,7 @@ a:hover {
 .alert {
   border-bottom: 10px solid #33BF95;
   background-color: #fff;
-  padding-top: 10px;
+  padding: 1em 0 .75em 0;
   clear: both;
 }
 .alert .img {

--- a/functions.php
+++ b/functions.php
@@ -45,7 +45,7 @@ function inn_enqueue() {
 		wp_enqueue_script( 'inn-tools', get_stylesheet_directory_uri() . '/js/inn.js', array( 'jquery' ), '1.1', true );
 	}
 
-	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/style.css', array('largo-stylesheet'), '201707075' );
+	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/style.css', array('largo-stylesheet'), '20171002' );
 
 	if ( is_archive( 'inn_member' ) ) {
 		wp_add_inline_script( 'jquery-core', "

--- a/less/style.less
+++ b/less/style.less
@@ -49,9 +49,27 @@ Version:        0.2.0
   margin-left: 0;
 }
 .alert {
-  padding: 3px 2.5%;
-  background-color: #df4646;
-  width: 95%;
+
+  // newsmatch styles for https://github.com/INN/inn/issues/51
+  border-bottom:10px solid #33BF95;
+  background-color: #fff;
+  padding-top: 10px;
+  .img {
+    margin:.75em 0 15px 0;
+  }
+  @media (max-width: 768px) {
+    text-align: center;
+    padding: 1em 2.5%;
+    .img {
+      display: block;
+      margin: 0 auto;
+    }
+    img {
+    }
+  }
+
+  //background-color: #df4646;
+  // width: 95%;
   clear: both;
   p {
     margin-bottom: 0;

--- a/less/style.less
+++ b/less/style.less
@@ -53,7 +53,7 @@ Version:        0.2.0
   // newsmatch styles for https://github.com/INN/inn/issues/51
   border-bottom:10px solid #33BF95;
   background-color: #fff;
-  padding-top: 10px;
+  padding: 1em 0 .75em 0;
   .img {
     margin:.75em 0 15px 0;
   }

--- a/partials/alert.php
+++ b/partials/alert.php
@@ -1,3 +1,10 @@
-<div class="alert">
-	<p><strong><a href="/project/news-match/">Apply to News Match 2017 by September 30</a></strong></p>
+<div class="alert" style="background-color: #fff;">
+	<p>
+		<a class="img" href="https://www.newsmatch.org/" style="">
+			<img src="https://giving-day-content.givegab.com/inn2017/app/images/day-of-giving-logo-horizontal.svg" alt="News Match: Quality journalism matters." width="220" >
+		</a>
+		<strong>
+			<a href="https://www.newsmatch.org/" style="color:#33BF95;">Donate now and double your impact. </a>
+		</strong>
+	</p>
 </div>


### PR DESCRIPTION
For https://github.com/INN/inn/issues/51

## Changes

- New styles and `partials/alert.php` for the News Match alert; see https://github.com/INN/inn/issues/51
- updates the cachebuster string https://github.com/INN/inn/blob/6c2e9ba/functions.php#L48

<img width="1368" alt="screen shot 2017-10-02 at 11 29 48 am" src="https://user-images.githubusercontent.com/1754187/31088400-8422ec9a-a76e-11e7-83ed-c1234f8c9db5.png">
<img width="563" alt="screen shot 2017-10-02 at 11 29 59 am" src="https://user-images.githubusercontent.com/1754187/31088401-84240558-a76e-11e7-9f36-5c1deea6fd98.png">
<img width="376" alt="screen shot 2017-10-02 at 11 30 10 am" src="https://user-images.githubusercontent.com/1754187/31088399-8422021c-a76e-11e7-8766-52931e7754fa.png">

http://inndev.staging.wpengine.com/

## Questions

What's the final messaging wording going to be?

## Why

For https://github.com/INN/inn/issues/51 and https://secure.helpscout.net/conversation/440796471/1335/