### PR TITLE
1678 banner redux

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -56,7 +56,7 @@
   line-height: 1.7em;
 }
 .normal h3 span {
-  color: #555555;
+  color: #555;
 }
 .interstitial {
   margin-bottom: 5em;
@@ -106,7 +106,7 @@
   font-size: 22px;
 }
 #news-and-benefits-and-funders.row-fluid .largo-recent-posts .byline {
-  color: #aaaaaa;
+  color: #aaa;
 }
 #news-and-benefits-and-funders.row-fluid .largo-recent-posts .post-lead {
   margin-bottom: 1.7em;
@@ -150,7 +150,7 @@
   font-size: 18px;
 }
 #news-and-benefits-and-funders.row-fluid li a {
-  color: #555555;
+  color: #555;
 }
 #news-and-benefits-and-funders.row-fluid li a:hover {
   color: #09c9ff;

--- a/css/press.css
+++ b/css/press.css
@@ -6,7 +6,7 @@
   margin-bottom: 0.5em;
 }
 .type-argolinks h3 a {
-  color: #555555;
+  color: #555;
 }
 .type-argolinks h3 a:hover {
   color: #09c9ff;

--- a/css/style.css
+++ b/css/style.css
@@ -32,10 +32,10 @@ button,
 select,
 textarea {
   font-family: "effra", helvetica, sans-serif;
-  color: #555555;
+  color: #555;
 }
 h1 {
-  color: #333333;
+  color: #333;
 }
 textarea,
 input[type="text"],
@@ -81,7 +81,7 @@ a:hover {
 }
 .btn.btn-primary {
   color: #fff;
-  background-color: #f77710;
+  background-color: #F77710;
 }
 .btn.btn-primary:hover {
   background-color: #df6807;
@@ -113,7 +113,7 @@ a:hover {
   height: 58px;
 }
 .footer-bg {
-  background-color: #555555;
+  background-color: #555;
 }
 #site-footer .widgettitle,
 #site-footer li.menu-label,
@@ -131,7 +131,7 @@ a:hover {
   padding: 0;
 }
 #site-footer a {
-  color: #aaaaaa;
+  color: #aaa;
 }
 #site-footer a:hover {
   color: #09c9ff;
@@ -272,7 +272,7 @@ a:hover {
   margin-bottom: 0.5em;
 }
 .stories h2.entry-title a {
-  color: #555555;
+  color: #555;
 }
 .stories h2.entry-title a:hover {
   color: #09c9ff;
@@ -281,17 +281,17 @@ a:hover {
   display: none;
 }
 .type-pull-quote {
-  border-left: 1px solid #aaaaaa;
+  border-left: 1px solid #aaa;
   padding-left: 40px;
-  color: #555555;
+  color: #555;
 }
 @media (max-width: 768px) {
   .type-pull-quote {
     padding: 20px 10px;
     text-align: center;
     border: none;
-    border-top: 3px solid #555555;
-    border-bottom: 3px solid #555555;
+    border-top: 3px solid #555;
+    border-bottom: 3px solid #555;
     margin: 0 auto 1em;
     max-width: 90%;
   }
@@ -308,7 +308,7 @@ a:hover {
 }
 .gform_wrapper.donation_form_wrapper .gsection,
 .gform_wrapper.membership_form_wrapper .gsection {
-  border-bottom: 1px solid #aaaaaa;
+  border-bottom: 1px solid #aaa;
 }
 .gform_wrapper.donation_form_wrapper .field_sublabel_above,
 .gform_wrapper.membership_form_wrapper .field_sublabel_above {
@@ -349,7 +349,7 @@ a:hover {
 .gform_wrapper.membership_form_wrapper .gform_button[type=submit],
 .gform_wrapper.donation_form_wrapper .gform_next_button,
 .gform_wrapper.membership_form_wrapper .gform_next_button {
-  background-color: #f77710;
+  background-color: #F77710;
   position: relative;
   top: -4px;
 }
@@ -415,7 +415,7 @@ a:hover {
   color: #fff;
 }
 .gform_wrapper.donation_form_wrapper ul.gfield_radio li input[type=radio]:checked + label {
-  background-color: #f77710;
+  background-color: #F77710;
   font-weight: 500;
 }
 @media (max-width: 480px) {
@@ -548,7 +548,6 @@ a:hover {
 }
 .alert p {
   margin-bottom: 0;
-  color: #fff;
   font-family: "effra", helvetica, sans-serif;
   text-align: center;
 }
@@ -665,7 +664,7 @@ h5.byline {
 #hero,
 section.interstitial {
   max-width: 100%;
-  background-color: #555555;
+  background-color: #555;
 }
 section,
 .interstitial .content {
@@ -711,7 +710,7 @@ section.normal h3 span {
   max-width: 100%;
   padding: 3em;
   margin: 0 auto 3em;
-  background-color: #555555;
+  background-color: #555;
   color: #edf1f4;
 }
 .interstitial h3 {
@@ -786,7 +785,7 @@ section.normal h3 span {
   margin-bottom: 2em;
 }
 #quick-links h4 {
-  color: #555555;
+  color: #555;
   text-transform: uppercase;
 }
 @media (max-width: 600px) {
@@ -814,8 +813,8 @@ section.normal h3 span {
 }
 #programs h3,
 #member-info h3 {
-  background-color: #f77710;
-  color: #f77710;
+  background-color: #F77710;
+  color: #F77710;
 }
 @media (max-width: 600px) {
   #programs h3,
@@ -827,7 +826,7 @@ section.normal h3 span {
 }
 #programs h5 a:hover,
 #member-info h5 a:hover {
-  color: #f77710;
+  color: #F77710;
 }
 @media (max-width: 530px) {
   .single #content {
@@ -877,7 +876,7 @@ section.normal h3 span {
 }
 .internal-subnav-dropdown .choose-a-page {
   font-size: 16px;
-  color: #aaaaaa;
+  color: #aaa;
   margin: 0 0 0.5em 0;
 }
 body.normal.page #content.has-menu,

--- a/functions.php
+++ b/functions.php
@@ -45,7 +45,7 @@ function inn_enqueue() {
 		wp_enqueue_script( 'inn-tools', get_stylesheet_directory_uri() . '/js/inn.js', array( 'jquery' ), '1.1', true );
 	}
 
-	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/style.css', array('largo-stylesheet'), '201711155' );
+	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/css/style.css', array('largo-stylesheet'), '20180123' );
 
 	if ( is_archive( 'inn_member' ) ) {
 		wp_add_inline_script( 'jquery-core', "

--- a/homepages/assets/css/inn.css
+++ b/homepages/assets/css/inn.css
@@ -94,7 +94,7 @@
 }
 .home #main #supporters h3 {
   width: auto;
-  color: #555555;
+  color: #555;
   background-color: transparent;
   line-height: 1;
   margin: 0;
@@ -132,7 +132,7 @@
 }
 @media (max-width: 768px) {
   .home .sticky-nav-holder {
-    border-bottom: #aaaaaa 1px solid;
+    border-bottom: #aaa 1px solid;
   }
 }
 body.home.admin-bar .sticky-nav-holder {
@@ -140,7 +140,7 @@ body.home.admin-bar .sticky-nav-holder {
 }
 @media (max-width: 768px) {
   body.home.admin-bar .sticky-nav-holder {
-    border-bottom: #aaaaaa 1px solid;
+    border-bottom: #aaa 1px solid;
   }
 }
 #email img {

--- a/less/style.less
+++ b/less/style.less
@@ -73,7 +73,6 @@ Version:        0.2.0
   clear: both;
   p {
 	margin-bottom: 0;
-	color: #fff;
 	font-family: "effra", helvetica, sans-serif;
 	text-align: center;
 	a {

--- a/partials/alert.php
+++ b/partials/alert.php
@@ -1,10 +1,9 @@
 <div class="alert" style="background-color: #fff;">
 	<p>
-		<a class="img" href="https://www.newsmatch.org/" style="">
-			<img src="https://giving-day-content.givegab.com/inn2017/app/images/day-of-giving-logo-horizontal.svg" alt="News Match: Quality journalism matters." width="220" >
-		</a>
 		<strong>
-			<a href="https://www.newsmatch.org/" style="color:#33BF95;">Donate now and double your impact. </a>
+			Thank you
+			<a href="https://www.newsmatch.org/" style="color:#33BF95;">News Match</a>
+			donors for supporting nonprofit newsrooms!
 		</strong>
 	</p>
 </div>

--- a/style.css
+++ b/style.css
@@ -7,4 +7,7 @@ Author URI:     http://nerds.inn.org
 Template:       largo
 Version:        0.2.0
 */
-@import "css/style.css?201711155";
+
+/**
+ * Not actually enqueued; the primary styles are in css/style.css and are enqueued by a function in functions.php
+ */


### PR DESCRIPTION
## Changes

- removes the newsmatch logo
- changes the paragraph text color in the alert from #fff to the body copy color #555
- changes the enqueued stylesheet from `style.css` to `css/style.css`, and removes the redirect from `style.css`. `style.css` is no longer loaded by browsers; this saves us an HTTP query before styles are loaded.
- updates the cachebuster string

<img width="524" alt="screen shot 2018-01-23 at 7 44 02 pm" src="https://user-images.githubusercontent.com/1754187/35308766-3fbd98f4-0077-11e8-8a54-402e6c4bfc9e.png">
<img width="1151" alt="screen shot 2018-01-23 at 7 44 11 pm" src="https://user-images.githubusercontent.com/1754187/35308767-3fcb4332-0077-11e8-81e2-fd23d6f01d32.png">
<img width="1526" alt="screen shot 2018-01-23 at 7 44 21 pm" src="https://user-images.githubusercontent.com/1754187/35308768-3fd8c80e-0077-11e8-964d-6e279ab9f6f7.png">


## Questions

- Is the font weight okay at **bold** or should it be normal?
- #555?
- How do we feel about keeping the green just for that link?

## Why

HelpScout ticket 1678: https://secure.helpscout.net/conversation/506860125/1678/?folderId=1219602

> For right now would remove logo and add a banner/bar. Thank you News Match donors for supporting nonprofit newsrooms!
> Make News Match in that sentence still link to NewsMatch.org. We'll be updating that for year-around use.
