### PR TITLE
Update member count to 150+

### DIFF
--- a/archive-inn_member.php
+++ b/archive-inn_member.php
@@ -82,7 +82,7 @@ $states = array(
 		<header class="entry-header">
 			<h1 class="entry-title">Member Directory</h1>
 			<section class="entry-content">
-				<p>Every one of INN's 120+ members is a nonprofit, nonpartisan organization committed to donor transparency. <a href="https://inn.org/for-members/membership-standards/">Learn more about our membership standards</a>.<br>
+				<p>Every one of INN's 150+ members is a nonprofit, nonpartisan organization committed to donor transparency. <a href="https://inn.org/for-members/membership-standards/">Learn more about our membership standards</a>.<br>
 			</section>
 		</header>
 


### PR DESCRIPTION
## Changes

- Updates INN's member count from `120+` to `150+`.

## Why

For #57.

Hold off on merging this until we have confirmation that that number is right. I asked in our about-members slack channel.
