### PR TITLE
Changes to Press page's partial for Link Roundups edge case

### DIFF
--- a/partials/content-press.php
+++ b/partials/content-press.php
@@ -1,6 +1,10 @@
 <?php
 	get_template_part( 'partials/content', 'page' );
 
+	if ( ! class_exists( 'LinkRoundups' ) ) {
+		return;
+	}
+
 	global $wp_query;
 	// argo links
 	$query_args = array (
@@ -17,6 +21,7 @@
 
 	if ( $wp_query->have_posts() ) {
 		echo '<h3>INN in the Press</h3>';
+		echo '<!-- Powered by Link Roundups https://wordpress.org/plugins/link-roundups/ and https://github.com/INN/inn/blob/master/partials/content-press.php -->';
 
 		while ( $wp_query->have_posts() ) : $wp_query->the_post();
 			get_template_part( 'partials/content', 'argolinks' );


### PR DESCRIPTION
## Changes

- Adds check to `partials/content-press.php` to only display the press links if the Link Roundups plugin is active, because the Link Roundups plugin is necessary to display the 
- Provides a HTML comment describing how that section is powered, for people using a browser's dev tools

## Questions

Any objections to adding the comment?

## Why

For https://secure.helpscout.net/conversation/596235267/2089/, to make sure that the section won't be displayed if it's not going to function.