### PR TITLE
73 automate inn member count

### DIFF
--- a/archive-inn_member.php
+++ b/archive-inn_member.php
@@ -99,7 +99,7 @@ $states = array(
 						echo '<!-- check the logic here, something has gone wrong -->';
 					}
 				?>
-				members is a nonprofit, nonpartisan organization committed to donor transparency. <a href="https://inn.org/for-members/membership-standards/">Learn more about our membership standards</a>.<br>
+				members is a nonprofit, nonpartisan organization committed to editorial independence and transparency.</p>
 			</section>
 		</header>
 

--- a/archive-inn_member.php
+++ b/archive-inn_member.php
@@ -5,6 +5,7 @@
  * @package INN
  * @since 0.1
  * @filter largo_partial_by_post_type
+ * @see functions.php: inn_member_archive_query for significant modifications
  */
 get_header();
 $queried_object = get_queried_object();
@@ -82,7 +83,23 @@ $states = array(
 		<header class="entry-header">
 			<h1 class="entry-title">Member Directory</h1>
 			<section class="entry-content">
-				<p>Every one of INN's 150+ members is a nonprofit, nonpartisan organization committed to donor transparency. <a href="https://inn.org/for-members/membership-standards/">Learn more about our membership standards</a>.<br>
+				<p>Every one of INN's
+				<?php
+					/**
+					 * How many members? This many.
+					 *
+					 * Draws from the global query, which because of the pre_get_posts filter inn_member_archive_query contains <=500 INN members.
+					 * @since https://github.com/INN/inn/issues/73
+					 */
+					 global $wp_query;
+					if ( is_int( $wp_query->post_count ) && 0 < $wp_query->post_count ) {
+						echo (string) $wp_query->post_count;
+					} else {
+						echo '170+';
+						echo '<!-- check the logic here, something has gone wrong -->';
+					}
+				?>
+				members is a nonprofit, nonpartisan organization committed to donor transparency. <a href="https://inn.org/for-members/membership-standards/">Learn more about our membership standards</a>.<br>
 			</section>
 		</header>
 

--- a/css/landing.css
+++ b/css/landing.css
@@ -56,7 +56,7 @@
   line-height: 1.7em;
 }
 .normal h3 span {
-  color: #555555;
+  color: #555;
 }
 .interstitial {
   margin-bottom: 5em;
@@ -106,7 +106,7 @@
   font-size: 22px;
 }
 #news-and-benefits-and-funders.row-fluid .largo-recent-posts .byline {
-  color: #aaaaaa;
+  color: #aaa;
 }
 #news-and-benefits-and-funders.row-fluid .largo-recent-posts .post-lead {
   margin-bottom: 1.7em;
@@ -153,7 +153,7 @@
   font-size: 18px;
 }
 #news-and-benefits-and-funders.row-fluid li a {
-  color: #555555;
+  color: #555;
 }
 #news-and-benefits-and-funders.row-fluid li a:hover {
   color: #09c9ff;

--- a/css/members.css
+++ b/css/members.css
@@ -16,7 +16,7 @@ body.post-type-archive-inn_member #inn-members-no-results {
 body.post-type-archive-inn_member section {
   padding-left: 5%;
   padding-right: 5%;
-  max-width: 30em;
+  max-width: 45em;
 }
 body.single-inn_member h1.entry-title {
   margin-bottom: 0.5em;

--- a/css/members.css
+++ b/css/members.css
@@ -13,6 +13,11 @@ body.post-type-archive-inn_member #inn-members-no-results {
   text-align: center;
   flex: auto;
 }
+body.post-type-archive-inn_member section {
+  padding-left: 5%;
+  padding-right: 5%;
+  max-width: 30em;
+}
 body.single-inn_member h1.entry-title {
   margin-bottom: 0.5em;
   text-align: left;

--- a/css/press.css
+++ b/css/press.css
@@ -6,7 +6,7 @@
   margin-bottom: 0.5em;
 }
 .type-argolinks h3 a {
-  color: #555555;
+  color: #555;
 }
 .type-argolinks h3 a:hover {
   color: #09c9ff;

--- a/css/style.css
+++ b/css/style.css
@@ -32,10 +32,10 @@ button,
 select,
 textarea {
   font-family: "effra", helvetica, sans-serif;
-  color: #555555;
+  color: #555;
 }
 h1 {
-  color: #333333;
+  color: #333;
 }
 textarea,
 input[type="text"],
@@ -81,7 +81,7 @@ a:hover {
 }
 .btn.btn-primary {
   color: #fff;
-  background-color: #f77710;
+  background-color: #F77710;
 }
 .btn.btn-primary:hover {
   background-color: #df6807;
@@ -113,7 +113,7 @@ a:hover {
   height: 58px;
 }
 .footer-bg {
-  background-color: #555555;
+  background-color: #555;
 }
 #site-footer .widgettitle,
 #site-footer li.menu-label,
@@ -131,7 +131,7 @@ a:hover {
   padding: 0;
 }
 #site-footer a {
-  color: #aaaaaa;
+  color: #aaa;
 }
 #site-footer a:hover {
   color: #09c9ff;
@@ -272,7 +272,7 @@ a:hover {
   margin-bottom: 0.5em;
 }
 .stories h2.entry-title a {
-  color: #555555;
+  color: #555;
 }
 .stories h2.entry-title a:hover {
   color: #09c9ff;
@@ -281,17 +281,17 @@ a:hover {
   display: none;
 }
 .type-pull-quote {
-  border-left: 1px solid #aaaaaa;
+  border-left: 1px solid #aaa;
   padding-left: 40px;
-  color: #555555;
+  color: #555;
 }
 @media (max-width: 768px) {
   .type-pull-quote {
     padding: 20px 10px;
     text-align: center;
     border: none;
-    border-top: 3px solid #555555;
-    border-bottom: 3px solid #555555;
+    border-top: 3px solid #555;
+    border-bottom: 3px solid #555;
     margin: 0 auto 1em;
     max-width: 90%;
   }
@@ -308,7 +308,7 @@ a:hover {
 }
 .gform_wrapper.donation_form_wrapper .gsection,
 .gform_wrapper.membership_form_wrapper .gsection {
-  border-bottom: 1px solid #aaaaaa;
+  border-bottom: 1px solid #aaa;
 }
 .gform_wrapper.donation_form_wrapper .field_sublabel_above,
 .gform_wrapper.membership_form_wrapper .field_sublabel_above {
@@ -349,7 +349,7 @@ a:hover {
 .gform_wrapper.membership_form_wrapper .gform_button[type=submit],
 .gform_wrapper.donation_form_wrapper .gform_next_button,
 .gform_wrapper.membership_form_wrapper .gform_next_button {
-  background-color: #f77710;
+  background-color: #F77710;
   position: relative;
   top: -4px;
 }
@@ -415,7 +415,7 @@ a:hover {
   color: #fff;
 }
 .gform_wrapper.donation_form_wrapper ul.gfield_radio li input[type=radio]:checked + label {
-  background-color: #f77710;
+  background-color: #F77710;
   font-weight: 500;
 }
 @media (max-width: 480px) {
@@ -664,7 +664,7 @@ h5.byline {
 #hero,
 section.interstitial {
   max-width: 100%;
-  background-color: #555555;
+  background-color: #555;
 }
 section,
 .interstitial .content {
@@ -710,7 +710,7 @@ section.normal h3 span {
   max-width: 100%;
   padding: 3em;
   margin: 0 auto 3em;
-  background-color: #555555;
+  background-color: #555;
   color: #edf1f4;
 }
 .interstitial h3 {
@@ -785,7 +785,7 @@ section.normal h3 span {
   margin-bottom: 2em;
 }
 #quick-links h4 {
-  color: #555555;
+  color: #555;
   text-transform: uppercase;
 }
 @media (max-width: 600px) {
@@ -813,8 +813,8 @@ section.normal h3 span {
 }
 #programs h3,
 #member-info h3 {
-  background-color: #f77710;
-  color: #f77710;
+  background-color: #F77710;
+  color: #F77710;
 }
 @media (max-width: 600px) {
   #programs h3,
@@ -826,7 +826,7 @@ section.normal h3 span {
 }
 #programs h5 a:hover,
 #member-info h5 a:hover {
-  color: #f77710;
+  color: #F77710;
 }
 @media (max-width: 530px) {
   .single #content {
@@ -876,7 +876,7 @@ section.normal h3 span {
 }
 .internal-subnav-dropdown .choose-a-page {
   font-size: 16px;
-  color: #aaaaaa;
+  color: #aaa;
   margin: 0 0 0.5em 0;
 }
 body.normal.page #content.has-menu,

--- a/functions.php
+++ b/functions.php
@@ -45,7 +45,7 @@ function inn_enqueue() {
 		wp_enqueue_script( 'inn-tools', get_stylesheet_directory_uri() . '/js/inn.js', array( 'jquery' ), '1.1', true );
 	}
 
-	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/css/style.css', array('largo-stylesheet'), '20180123' );
+	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/css/style.css', array('largo-stylesheet'), '20180816' );
 
 	if ( is_archive( 'inn_member' ) ) {
 		wp_add_inline_script( 'jquery-core', "

--- a/homepages/assets/css/inn.css
+++ b/homepages/assets/css/inn.css
@@ -168,7 +168,7 @@
 }
 .home #main #supporters h3 {
   width: auto;
-  color: #555555;
+  color: #555;
   background-color: transparent;
   line-height: 1;
   margin: 0;
@@ -206,7 +206,7 @@
 }
 @media (max-width: 768px) {
   .home .sticky-nav-holder {
-    border-bottom: #aaaaaa 1px solid;
+    border-bottom: #aaa 1px solid;
   }
 }
 body.home.admin-bar .sticky-nav-holder {
@@ -214,7 +214,7 @@ body.home.admin-bar .sticky-nav-holder {
 }
 @media (max-width: 768px) {
   body.home.admin-bar .sticky-nav-holder {
-    border-bottom: #aaaaaa 1px solid;
+    border-bottom: #aaa 1px solid;
   }
 }
 #email img {

--- a/less/members.less
+++ b/less/members.less
@@ -21,7 +21,7 @@ body.post-type-archive-inn_member {
   section {
     padding-left: 5%;
     padding-right: 5%;
-    max-width: 30em;
+    max-width: 45em;
   }
 }
 

--- a/less/members.less
+++ b/less/members.less
@@ -18,6 +18,11 @@ body.post-type-archive-inn_member {
 		text-align: center;
 		flex: auto;
 	}
+  section {
+    padding-left: 5%;
+    padding-right: 5%;
+    max-width: 30em;
+  }
 }
 
 


### PR DESCRIPTION
## Changes

- As a follow-up to #59 and for #73, makes the INN member count on the member list page be the actual number of active members registered with the INN website, instead of being a round number.
- Updates wording in that statement, for #73.
- Adds some padding on the text, so it no longer runs up flat against the edge of the screen.

Before:

<img width="1357" alt="screen shot 2018-08-16 at 1 36 40 am" src="https://user-images.githubusercontent.com/1754187/44190454-e472e700-a0f4-11e8-84a2-bc40aa4d9fc2.png">
<img width="460" alt="screen shot 2018-08-16 at 1 36 50 am" src="https://user-images.githubusercontent.com/1754187/44190455-e472e700-a0f4-11e8-920c-36af1666d640.png">

After:

<img width="626" alt="screen shot 2018-08-16 at 1 30 56 am" src="https://user-images.githubusercontent.com/1754187/44190464-f2c10300-a0f4-11e8-924a-c8b1f9203035.png">
<img width="1068" alt="screen shot 2018-08-16 at 1 33 17 am" src="https://user-images.githubusercontent.com/1754187/44190465-f3599980-a0f4-11e8-862f-f7f1d98b8c1a.png">
<img width="1382" alt="screen shot 2018-08-16 at 1 33 38 am" src="https://user-images.githubusercontent.com/1754187/44190466-f3599980-a0f4-11e8-903d-ace9ad4f104f.png">

The padding-left and padding-right on the `<section>` that contains the intro text is `5%` to match the padding on the list items on smaller screen sizes:

<img width="592" alt="screen shot 2018-08-16 at 1 30 47 am" src="https://user-images.githubusercontent.com/1754187/44190491-15531c00-a0f5-11e8-9b07-a961ae641a33.png">

## Questions

@tylermachado, I'm merging and deploying this tonight because the deadline for this is the publication date on Sue's editorial, but if you have time to look at these styles tomorrow we might want to revise the 45em max-width.

## Why

Requested by Mara in Slack on 2018-08-15, captured in #73.
