### PR TITLE
Fix layout-breaking left margin on hero elements in single posts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,14 @@
 
 -
 -
-- <!-- if this updates styles, does it update the cachebuster string? https://github.com/INN/inn/blob/6c2e9ba/functions.php#L48 -->
 
 <!-- relevant screenshot here -->
+
+## Why
+
+<!-- who requested change, where? Is there a ticket URL or number for it? -->
 
 ## Questions
 
 <!-- prompts for feedback from reviewers -->
 
-## Why
-
-<!-- who requested change, where? Is there a ticket URL or number for it? -->

--- a/css/style.css
+++ b/css/style.css
@@ -1037,3 +1037,6 @@ body.inn_member_survey.woocommerce-account .woocommerce-MyAccount-navigation li.
     font-size: 85%;
   }
 }
+.single .hero.span12 {
+  margin-left: 0;
+}

--- a/functions.php
+++ b/functions.php
@@ -45,7 +45,12 @@ function inn_enqueue() {
 		wp_enqueue_script( 'inn-tools', get_stylesheet_directory_uri() . '/js/inn.js', array( 'jquery' ), '1.1', true );
 	}
 
-	wp_enqueue_style( 'largo-child-styles', get_stylesheet_directory_uri() . '/css/style.css', array('largo-stylesheet'), '20180816' );
+	wp_enqueue_style(
+		'largo-child-styles',
+		get_stylesheet_directory_uri() . '/css/style.css',
+		array('largo-stylesheet'),
+		filemtime( get_stylesheet_directory() . '/css/style.css' )
+	);
 
 	if ( is_archive( 'inn_member' ) ) {
 		wp_add_inline_script( 'jquery-core', "

--- a/less/style.less
+++ b/less/style.less
@@ -589,3 +589,8 @@ body.inn_member_survey.woocommerce-account {
 		}
 	}
 }
+
+// https://github.com/INN/largo/issues/1401
+.single .hero.span12 {
+  margin-left: 0;
+}


### PR DESCRIPTION

## Changes

- reimplement 6f8f3cef9a28eca5477f15160f7ec36c9737eefa for https://github.com/INN/largo/issues/1401 in the inn.org theme, but this time in `style.less` instead of `common.less`, meaning that this change is scoped just to the inn.org theme.
- removes left margin on hero element in single posts
- changes how the css stylesheet is enqueued so that we no longer have to bump the cachebuster string
- removes the cachebuster string from the pull request template

Before:

<img width="1090" alt="screen shot 2018-08-24 at 1 38 53 pm" src="https://user-images.githubusercontent.com/1754187/44600113-4fcc5100-a7a6-11e8-9794-248360f89deb.png">
<img width="1100" alt="screen shot 2018-08-24 at 1 39 01 pm" src="https://user-images.githubusercontent.com/1754187/44600114-4fcc5100-a7a6-11e8-9007-a8be90b0ace1.png">

After:

<img width="1237" alt="screen shot 2018-08-24 at 2 02 27 pm" src="https://user-images.githubusercontent.com/1754187/44600129-5bb81300-a7a6-11e8-85eb-e0307c6e84e0.png">

## Why

With the margin, the element was positioned such that the page was wider than the viewport.

## Questions

- [ ] what other single-page templates do we need to check for this besides the jobs template?
- [ ] why was https://github.com/INN/inn/commit/6f8f3cef9a28eca5477f15160f7ec36c9737eefa removed originally?

