### PR TITLE
add whitespace between the edge of the browser and text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -581,8 +581,10 @@ a:hover {
   padding: 0;
 }
 #main {
-  max-width: 1170px;
+  max-width: 1190px;
+  padding: 0 10px;
   margin: 4em auto;
+  box-sizing: border-box;
 }
 #main .row-fluid img.icon,
 #main .row-fluid a.program img {

--- a/homepages/assets/css/inn.css
+++ b/homepages/assets/css/inn.css
@@ -5,6 +5,7 @@
 .home #main {
   margin: 0;
   max-width: 100%;
+  padding: 0;
 }
 .home #main .row-fluid .span12 {
   text-align: center;

--- a/homepages/assets/less/inn.less
+++ b/homepages/assets/less/inn.less
@@ -8,6 +8,8 @@
   #main {
     margin: 0;
     max-width: 100%;
+    padding: 0;
+
     .row-fluid .span12 {
       text-align:center;
       padding:0 12em;

--- a/less/style.less
+++ b/less/style.less
@@ -98,8 +98,11 @@ Version:        0.2.0
   padding: 0;
 }
 #main {
-  max-width: 1170px;
+  max-width: 1190px;
+  padding: 0 10px;
   margin: 4em auto;
+  box-sizing: border-box;
+
   .row-fluid {
 	img.icon,
 	a.program img {


### PR DESCRIPTION
## Changes

- Prevents the body from running up against the edge of the browser on internal pages
- Allows the homepage fullwidth stuff to run up against the edge of the browser

## Why

No ticket, low priority.

Because I noticed that this was happening on non-fullscreen browsers.

## Questions

what pages do we need to test this against?
- [ ] homepage
- [ ] products
- [ ] blog posts
- [ ] events
- [ ] members
- [ ] authors
