### PR TITLE
Remove search box from main nav when on the search page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The Investigative News Network WordPress Theme
+The Institute for Nonprofit News WordPress Theme
 ===
 
 This is the WordPress child theme used for https://inn.org.

--- a/functions.php
+++ b/functions.php
@@ -197,7 +197,9 @@ function inn_print_scripts() {
  * Add search box to main nav
  */
 function inn_add_search_box() {
-	get_template_part( 'partials/inn-nav-search-form' );
+	if ( ! is_search() ) {
+		get_template_part( 'partials/inn-nav-search-form' );
+	}
 }
 add_action( 'largo_after_main_nav_shelf', 'inn_add_search_box' );
 


### PR DESCRIPTION
## Changes

- Removes the search box from the main nav when on the search page

before:

<img width="985" alt="screen shot 2018-12-17 at 1 20 40 pm" src="https://user-images.githubusercontent.com/1754187/50106709-94b93f00-01fe-11e9-9fbe-59182da459a7.png">


after:
<img width="988" alt="screen shot 2018-12-17 at 1 20 11 pm" src="https://user-images.githubusercontent.com/1754187/50106683-81a66f00-01fe-11e9-8680-461a8517c1b6.png">

## Why

Because I noticed the duplication while working on https://github.com/INN/largo/issues/1602

## Questions

- [x] Are we planning on keeping the main nav search item?
- [x] should this PR be against a different branch than `master`? @tylermachado I know you have work going on in #93; should this PR be against that branch?
