### PR TITLE
114 best of nonprofit template changes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,6 +6,7 @@ define( 'INN_ABOUT_PAGE_ID', 2212 );
 define( 'INN_PROGRAMS_PAGE_ID', 2587 );
 define( 'INN_MEMBERS_PAGE_ID', 234260 );
 define( 'INN_SERVICES_PAGE_ID', 654834);
+define( 'INN_PARENT_PAGE_IDS', array( 778595 ) );
 define( 'SHOW_GLOBAL_NAV', true );
 
 // Includes

--- a/partials/internal-subnav-dropdown.php
+++ b/partials/internal-subnav-dropdown.php
@@ -3,117 +3,102 @@
  * The dropdown used on mobile for these pages
  */
 
-$about_pg_id = INN_ABOUT_PAGE_ID;
-$programs_pg_id = INN_PROGRAMS_PAGE_ID;
-$members_pg_id = INN_MEMBERS_PAGE_ID;
-$services_pg_id = INN_SERVICES_PAGE_ID;
-INN_PARENT_PAGE_IDS;
+// should we show a menu? let's find out.
+$show_menu_title = '';
+$show_menu = false;
+$ancestors = get_post_ancestors( $post );
 
-//is this a page or a post in the projects post type
-if ( is_page() || is_singular( 'pauinn_project' ) ) {
-	// should we show a menu? let's find out.
-	$show_menu_title = '';
-	$show_menu = false;
-	$ancestors = get_post_ancestors( $post );
+/*
+ * @todo: rejigger this whole section with an array ( id => 'menu title', ... );
+ */
 
-	/*
-	 * @todo: rejigger this whole section with an array ( id => 'menu title', ... );
-	 */
+// bascially all child pages of the about or members pages + all the posts in the projects post type get the side menu
+if ( is_page( INN_ABOUT_PAGE_ID ) || in_array( INN_ABOUT_PAGE_ID , $ancestors) ) {
+	$show_menu_title = 'About';
+	$show_menu = true;
+	$pg_id = INN_ABOUT_PAGE_ID;
+}
+if ( is_page( INN_MEMBERS_PAGE_ID ) || in_array( INN_MEMBERS_PAGE_ID , $ancestors) ) {
+	$show_menu_title = 'Membership';
+	$show_menu = true;
+	$pg_id = INN_MEMBERS_PAGE_ID;
+}
+if ( is_singular( 'pauinn_project' ) || is_page( INN_PROGRAMS_PAGE_ID ) ) {
+	$show_menu_title = 'Projects';
+	$show_menu = true;
+	$pg_id = INN_PROGRAMS_PAGE_ID;
+}
+if ( is_page( INN_SERVICES_PAGE_ID ) || in_array( INN_SERVICES_PAGE_ID , $ancestors ) ) {
+	$show_menu_title = 'Services';
+	$show_menu = true;
+	$pg_id = INN_SERVICES_PAGE_ID;
+} 
 
-	// bascially all child pages of the about or members pages + all the posts in the projects post type get the side menu
-	if ( is_page( $about_pg_id ) || in_array( $about_pg_id , $ancestors) ) {
-		$show_menu_title = 'About';
-		$show_menu = true;
-		$pg_id = $about_pg_id;
-	}
-	if ( is_page( $members_pg_id ) || in_array( $members_pg_id , $ancestors) ) {
-		$show_menu_title = 'Membership';
-		$show_menu = true;
-		$pg_id = $members_pg_id;
-	}
-	if ( is_singular( 'pauinn_project' ) || is_page( $programs_pg_id ) ) {
-		$show_menu_title = 'Projects';
-		$show_menu = true;
-		$pg_id = $programs_pg_id;
-	}
-	if ( is_page( $services_pg_id ) || in_array( $services_pg_id , $ancestors ) ) {
-		$show_menu_title = 'Services';
-		$show_menu = true;
-		$pg_id = $services_pg_id;
-	} 
+// check if this post or its parents are in the array of post IDs INN_PARENT_PAGE_IDS
+$intersection = array_intersect( $ancestors, INN_PARENT_PAGE_IDS );
+if ( ! empty( $intersection ) ) {
+	// one or more of the post's parents are in the array
+	$show_menu_title = "The Best of Nonprofit News";
+	$show_menu = true;
+	$pg_id = end( $ancestors );
+}
+if ( in_array( get_the_ID(), INN_PARENT_PAGE_IDS ) ) {
+	// the post itself is in the array
+	$show_menu_title = "The Best of Nonprofit News";
+	$show_menu = true;
+	$pg_id = get_the_ID();
+}
 
-	// check if this post or its parents are in the array of post IDs INN_PARENT_PAGE_IDS
-	$intersection = array_intersect( $ancestors, INN_PARENT_PAGE_IDS );
-	if ( ! empty( $intersection ) ) {
-		// one or more of the post's parents are in the array
-		$show_menu_title = "The Best of Nonprofit News";
-		$show_menu = true;
-		$pg_id = end( $ancestors );
-	}
-	if ( in_array( get_the_ID(), INN_PARENT_PAGE_IDS ) ) {
-		// the post itself is in the array
-		$show_menu_title = "The Best of Nonprofit News";
-		$show_menu = true;
-		$pg_id = get_the_ID();
-	}
+// yep, we should show a menu, modify the layout appropriately
+if ( $show_menu === true ) {
+	?>
+	<div class="hidden-desktop visible-tablet internal-subnav-dropdown">
+		<h3><a href="<?php echo get_permalink( $pg_id ); ?>"><?php echo $show_menu_title; ?></a></h3>
+		<p class="choose-a-page">Choose a page...</p>
+		<select class="internal-subnav">
+			<?php
+				if ( $show_menu_title === 'Projects' ) {
+					// projects has its own special case
+					// project pages show a list of projects, add the current_page_item class if necessary for consistency
+					$terms = get_terms( 'pauinn_project_tax', array( 'hide_empty' => false ) );
 
-	error_log(var_export( $show_menu_title , true));
+					if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+						foreach ( $terms as $term ) {
+							$term_link = '/project/' . $term->slug;
+							if ( is_single( $term->name ) ) {
+								echo '<option data-href="' . $term_link . '" selected class="current_page_item">' . $term->name . '</option>';
+							} else {
+								echo '<option data-href="' . $term_link . '">' . $term->name . '</option>';
+							}
+						}
+					}
+				} else if ( ! empty ( $pg_id ) ) {
+				// about and member pages and children get their respective page trees
+					$show_pages = get_pages('child_of=' . $pg_id);
 
-	// yep, we should show a menu, modify the layout appropriately
-	if ( $show_menu === true ) { ?>
-		<div class="hidden-desktop visible-tablet internal-subnav-dropdown">
-			<h3><a href="<?php echo get_permalink( $pg_id ); ?>"><?php echo $show_menu_title; ?></a></h3>
-			<p class="choose-a-page">Choose a page...</p>
-			<select class="internal-subnav">
-		<?php
-	}
-
-	if ( $show_menu_title === 'Projects' ) {
-		// projects has its own special case
-		// project pages show a list of projects, add the current_page_item class if necessary for consistency
-		$terms = get_terms( 'pauinn_project_tax', array( 'hide_empty' => false ) );
-
-		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-			foreach ( $terms as $term ) {
-				$term_link = '/project/' . $term->slug;
-				if ( is_single( $term->name ) ) {
-					echo '<option data-href="' . $term_link . '" selected class="current_page_item">' . $term->name . '</option>';
-				} else {
-					echo '<option data-href="' . $term_link . '">' . $term->name . '</option>';
+					foreach ($show_pages as $show_page) {
+						if (is_page($show_page->ID))
+							echo '<option selected data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
+						else
+							echo '<option data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
+					}
 				}
-			}
-		}
-	} else {
-	// about and member pages and children get their respective page trees
-		$show_pages = get_pages('child_of=' . $pg_id);
+			?>
+		</select>
+	</div>
 
-		foreach ($show_pages as $show_page) {
-			if (is_page($show_page->ID))
-				echo '<option selected data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
-			else
-				echo '<option data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
-		}
-	}
+	<script type="text/javascript">
+		(function() {
+			var $ = jQuery;
 
-
-	// close the menu div
-	if ( $show_menu === true ) {
-		echo '</select></div>';
-
-		?>
-		<script type="text/javascript">
-			(function() {
-				var $ = jQuery;
-
-				$(function() {
-					$('select.internal-subnav').on('change', function(event) {
-						var href = $(this).find(':selected').data('href');
-						window.location.href = href;
-						return false;
-					});
+			$(function() {
+				$('select.internal-subnav').on('change', function(event) {
+					var href = $(this).find(':selected').data('href');
+					window.location.href = href;
+					return false;
 				});
-			})();
-		</script>
-		<?php
-	}
+			});
+		})();
+	</script>
+	<?php
 }

--- a/partials/internal-subnav-dropdown.php
+++ b/partials/internal-subnav-dropdown.php
@@ -1,53 +1,15 @@
 <?php
 /**
  * The dropdown used on mobile for these pages
+ *
+ * Depends on the following variables being populated:
+ *
+ * @param Bool $show_menu
+ * @param String $show_menu_title the title of the menu
+ * @param Array $ancestors An array of post IDs from nearest to farthest ancestor
+ * @Param Int $pg_id The post ID of the menu parent
  */
 
-// should we show a menu? let's find out.
-$show_menu_title = '';
-$show_menu = false;
-$ancestors = get_post_ancestors( $post );
-
-/*
- * @todo: rejigger this whole section with an array ( id => 'menu title', ... );
- */
-
-// bascially all child pages of the about or members pages + all the posts in the projects post type get the side menu
-if ( is_page( INN_ABOUT_PAGE_ID ) || in_array( INN_ABOUT_PAGE_ID , $ancestors) ) {
-	$show_menu_title = 'About';
-	$show_menu = true;
-	$pg_id = INN_ABOUT_PAGE_ID;
-}
-if ( is_page( INN_MEMBERS_PAGE_ID ) || in_array( INN_MEMBERS_PAGE_ID , $ancestors) ) {
-	$show_menu_title = 'Membership';
-	$show_menu = true;
-	$pg_id = INN_MEMBERS_PAGE_ID;
-}
-if ( is_singular( 'pauinn_project' ) || is_page( INN_PROGRAMS_PAGE_ID ) ) {
-	$show_menu_title = 'Projects';
-	$show_menu = true;
-	$pg_id = INN_PROGRAMS_PAGE_ID;
-}
-if ( is_page( INN_SERVICES_PAGE_ID ) || in_array( INN_SERVICES_PAGE_ID , $ancestors ) ) {
-	$show_menu_title = 'Services';
-	$show_menu = true;
-	$pg_id = INN_SERVICES_PAGE_ID;
-} 
-
-// check if this post or its parents are in the array of post IDs INN_PARENT_PAGE_IDS
-$intersection = array_intersect( $ancestors, INN_PARENT_PAGE_IDS );
-if ( ! empty( $intersection ) ) {
-	// one or more of the post's parents are in the array
-	$show_menu_title = "The Best of Nonprofit News";
-	$show_menu = true;
-	$pg_id = end( $ancestors );
-}
-if ( in_array( get_the_ID(), INN_PARENT_PAGE_IDS ) ) {
-	// the post itself is in the array
-	$show_menu_title = "The Best of Nonprofit News";
-	$show_menu = true;
-	$pg_id = get_the_ID();
-}
 
 // yep, we should show a menu, modify the layout appropriately
 if ( $show_menu === true ) {

--- a/partials/internal-subnav-dropdown.php
+++ b/partials/internal-subnav-dropdown.php
@@ -1,60 +1,76 @@
 <?php
+/**
+ * The dropdown used on mobile for these pages
+ */
 
 $about_pg_id = INN_ABOUT_PAGE_ID;
 $programs_pg_id = INN_PROGRAMS_PAGE_ID;
 $members_pg_id = INN_MEMBERS_PAGE_ID;
 $services_pg_id = INN_SERVICES_PAGE_ID;
+INN_PARENT_PAGE_IDS;
 
 //is this a page or a post in the projects post type
 if ( is_page() || is_singular( 'pauinn_project' ) ) {
 	// should we show a menu? let's find out.
-	$show_menu = '';
+	$show_menu_title = '';
+	$show_menu = false;
 	$ancestors = get_post_ancestors( $post );
 
+	/*
+	 * @todo: rejigger this whole section with an array ( id => 'menu title', ... );
+	 */
+
 	// bascially all child pages of the about or members pages + all the posts in the projects post type get the side menu
-	if ( is_page( $about_pg_id ) || in_array( $about_pg_id , $ancestors) )
-		$show_menu = 'About';
-	if ( is_page( $members_pg_id ) || in_array( $members_pg_id , $ancestors) )
-		$show_menu = 'Membership';
-	if ( is_singular( 'pauinn_project' ) || is_page( $programs_pg_id ) )
-		$show_menu = 'Projects';
+	if ( is_page( $about_pg_id ) || in_array( $about_pg_id , $ancestors) ) {
+		$show_menu_title = 'About';
+		$show_menu = true;
+		$pg_id = $about_pg_id;
+	}
+	if ( is_page( $members_pg_id ) || in_array( $members_pg_id , $ancestors) ) {
+		$show_menu_title = 'Membership';
+		$show_menu = true;
+		$pg_id = $members_pg_id;
+	}
+	if ( is_singular( 'pauinn_project' ) || is_page( $programs_pg_id ) ) {
+		$show_menu_title = 'Projects';
+		$show_menu = true;
+		$pg_id = $programs_pg_id;
+	}
 	if ( is_page( $services_pg_id ) || in_array( $services_pg_id , $ancestors ) ) {
-		$show_menu = 'Services';
+		$show_menu_title = 'Services';
+		$show_menu = true;
+		$pg_id = $services_pg_id;
+	} 
+
+	// check if this post or its parents are in the array of post IDs INN_PARENT_PAGE_IDS
+	$intersection = array_intersect( $ancestors, INN_PARENT_PAGE_IDS );
+	if ( ! empty( $intersection ) ) {
+		// one or more of the post's parents are in the array
+		$show_menu_title = "The Best of Nonprofit News";
+		$show_menu = true;
+		$pg_id = end( $ancestors );
+	}
+	if ( in_array( get_the_ID(), INN_PARENT_PAGE_IDS ) ) {
+		// the post itself is in the array
+		$show_menu_title = "The Best of Nonprofit News";
+		$show_menu = true;
+		$pg_id = get_the_ID();
 	}
 
+	error_log(var_export( $show_menu_title , true));
+
 	// yep, we should show a menu, modify the layout appropriately
-	if ( $show_menu != '' ) { ?>
+	if ( $show_menu === true ) { ?>
 		<div class="hidden-desktop visible-tablet internal-subnav-dropdown">
-			<h3><a href="<?php echo get_permalink( $pg_id ); ?>"><?php echo $show_menu; ?></a></h3>
+			<h3><a href="<?php echo get_permalink( $pg_id ); ?>"><?php echo $show_menu_title; ?></a></h3>
 			<p class="choose-a-page">Choose a page...</p>
 			<select class="internal-subnav">
 		<?php
 	}
 
-	// about and member pages and children get their respective page trees
-	if ( $show_menu == 'About' || $show_menu == 'Membership' || $show_menu == 'Services') {
-		switch ( $show_menu ) {
-			case 'About':
-				$pg_id = $about_pg_id;
-				break;
-			case 'Membership':
-				$pg_id = $members_pg_id;
-				break;
-			case 'Services':
-				$pg_id = $services_pg_id;
-				break;
-		}
-		$show_pages = get_pages('child_of=' . $pg_id);
-
-		foreach ($show_pages as $show_page) {
-			if (is_page($show_page->ID))
-				echo '<option selected data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
-			else
-				echo '<option data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
-		}
-
-	// project pages show a list of projects, add the current_page_item class if necessary for consistency
-	} else if ( $show_menu == 'Projects' ) {
+	if ( $show_menu_title === 'Projects' ) {
+		// projects has its own special case
+		// project pages show a list of projects, add the current_page_item class if necessary for consistency
 		$terms = get_terms( 'pauinn_project_tax', array( 'hide_empty' => false ) );
 
 		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
@@ -67,10 +83,21 @@ if ( is_page() || is_singular( 'pauinn_project' ) ) {
 				}
 			}
 		}
+	} else {
+	// about and member pages and children get their respective page trees
+		$show_pages = get_pages('child_of=' . $pg_id);
+
+		foreach ($show_pages as $show_page) {
+			if (is_page($show_page->ID))
+				echo '<option selected data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
+			else
+				echo '<option data-href="' . get_permalink($show_page->ID) . '">' . $show_page->post_title . '</option>';
+		}
 	}
 
+
 	// close the menu div
-	if ( $show_menu != '' ) {
+	if ( $show_menu === true ) {
 		echo '</select></div>';
 
 		?>

--- a/single-one-column.php
+++ b/single-one-column.php
@@ -102,10 +102,20 @@ if ( is_page() || is_singular( 'pauinn_project' ) ) {
 	if ( ! empty( $show_menu ) ) {
 		echo '</div>';
 	}
+
+	// load the mobile-nav implementation of the above item: a <select> with <options>
+	largo_render_template(
+		'partials/internal',
+		'subnav-dropdown',
+		array( 
+			'ancestors' => $ancestors,
+			'show_menu_title' => $show_menu_title,
+			'show_menu' => $show_menu,
+			'pg_id' => $pg_id,
+		),
+	);
 }
 
-// load the mobile-nav implementation of the above item: a <select> with <options>
-get_template_part( 'partials/internal-subnav-dropdown' );
 
 if ( is_page( 'press' ) || is_page( 'news' ) ) {
 	$content_class .= ' stories';

--- a/single-one-column.php
+++ b/single-one-column.php
@@ -21,10 +21,10 @@ add_filter( 'body_class', function( $classes ) {
 
 get_header();
 
-$about_pg_id = INN_ABOUT_PAGE_ID;
-$programs_pg_id = INN_PROGRAMS_PAGE_ID;
-$members_pg_id = INN_MEMBERS_PAGE_ID;
-$services_pg_id = INN_SERVICES_PAGE_ID;
+/*
+ * @todo: rejigger this whole section with an array ( id => 'menu title', ... );
+ */
+
 $content_class = 'span12';
 
 // is this a page or a post in the projects post type?
@@ -34,86 +34,98 @@ if ( is_page() || is_singular( 'pauinn_project' ) ) {
 	$show_menu = '';
 	$ancestors = get_post_ancestors( $post );
 
-	// bascially all child pages of the about, members or services pages 
-	// and all the posts in the projects post type
-	// get the side menu
-	if ( is_page( $about_pg_id ) || in_array( $about_pg_id, $ancestors, true ) ) {
-		$show_menu = 'About';
+	/*
+	 * Check whether this post needs a side menu
+	 */
+	// bascially all child pages of the about or members pages + all the posts in the projects post type get the side menu
+	if ( is_page( INN_ABOUT_PAGE_ID ) || in_array( INN_ABOUT_PAGE_ID , $ancestors) ) {
+		$show_menu_title = 'About';
+		$show_menu = true;
+		$pg_id = INN_ABOUT_PAGE_ID;
 	}
-	if ( is_page( $members_pg_id ) || in_array( $members_pg_id, $ancestors, true ) ) {
-		$show_menu = 'Membership';
+	if ( is_page( INN_MEMBERS_PAGE_ID ) || in_array( INN_MEMBERS_PAGE_ID , $ancestors) ) {
+		$show_menu_title = 'Membership';
+		$show_menu = true;
+		$pg_id = INN_MEMBERS_PAGE_ID;
 	}
-	if ( is_singular( 'pauinn_project' ) || is_page( $programs_pg_id ) ) {
-		$show_menu = 'Projects';
+	if ( is_singular( 'pauinn_project' ) || is_page( INN_PROGRAMS_PAGE_ID ) ) {
+		$show_menu_title = 'Projects';
+		$show_menu = true;
+		$pg_id = INN_PROGRAMS_PAGE_ID;
 	}
-	if ( is_page( $services_pg_id ) || in_array( $services_pg_id , $ancestors ) ) {
-		$show_menu = 'Services';
+	if ( is_page( INN_SERVICES_PAGE_ID ) || in_array( INN_SERVICES_PAGE_ID , $ancestors ) ) {
+		$show_menu_title = 'Services';
+		$show_menu = true;
+		$pg_id = INN_SERVICES_PAGE_ID;
+	} 
+
+	// check if this post or its parents are in the array of post IDs INN_PARENT_PAGE_IDS
+	$intersection = array_intersect( $ancestors, INN_PARENT_PAGE_IDS );
+	if ( ! empty( $intersection ) ) {
+		// one or more of the post's parents are in the array
+		$show_menu_title = "The Best of Nonprofit News";
+		$show_menu = true;
+		$pg_id = end( $ancestors );
+	}
+	if ( in_array( get_the_ID(), INN_PARENT_PAGE_IDS ) ) {
+		// the post itself is in the array
+		$show_menu_title = "The Best of Nonprofit News";
+		$show_menu = true;
+		$pg_id = get_the_ID();
 	}
 
+	/*
+	 * determine whether to show the side menu, and display it
+	 */
 	if ( ! empty( $show_menu ) ) {
 		// yep, we should show a menu, modify the layout appropriately.
 		$content_class = 'span9 has-menu';
 		echo '<div class="internal-subnav span3 visible-desktop">';
-	}
 
-	// about, member and services pages and children get their respective page trees.
-	switch ( $show_menu ) {
-		case 'About':
-			$pg_id = $about_pg_id;
-			break;
-		case 'Membership':
-			$pg_id = $members_pg_id;
-			break;
-		case 'Services':
-			$pg_id = $services_pg_id;
-			break;
-	}
+		if ( $show_menu_title === 'Projects' ) {
+			// project pages show a list of projects,
+			// and add the current_page_item class if necessary for consistency.
+			echo '<h3>Projects</h3>';
+			$terms = get_terms( 'pauinn_project_tax', array( 'hide_empty' => false ) );
 
-	if ( ! empty( $pg_id ) ) {
-		printf(
-			'<h3><a href="%1$s">%2$s</a></h3>',
-			get_permalink( $pg_id ),
-			wp_kses_post( __( $show_menu, 'inn' ) )
-		);
-		echo '<ul>';
-			wp_list_pages( 'title_li=&child_of=' . $pg_id . '&echo=1' );
-		echo '</ul>';
-	} elseif ( $show_menu === 'Projects' ) {
-		// project pages show a list of projects,
-		// and add the current_page_item class if necessary for consistency.
-		echo '<h3>Projects</h3>';
-		$terms = get_terms( 'pauinn_project_tax', array( 'hide_empty' => false ) );
-
-		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-			echo '<ul>';
-			foreach ( $terms as $term ) {
-				$term_link = '/project/' . $term->slug . '/';
-				if ( is_single( $term->name ) ) {
-					echo '<li class="current_page_item"><a href="' . esc_attr( $term_link ) . '">' . wp_kses_post( $term->name ) . '</a></li>';
-				} else {
-					echo '<li><a href="' . esc_attr( $term_link ) . '">' . wp_kses_post( $term->name ) . '</a></li>';
+			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+				echo '<ul>';
+				foreach ( $terms as $term ) {
+					$term_link = '/project/' . $term->slug . '/';
+					if ( is_single( $term->name ) ) {
+						echo '<li class="current_page_item"><a href="' . esc_attr( $term_link ) . '">' . wp_kses_post( $term->name ) . '</a></li>';
+					} else {
+						echo '<li><a href="' . esc_attr( $term_link ) . '">' . wp_kses_post( $term->name ) . '</a></li>';
+					}
 				}
+				echo '</ul>';
 			}
+		} else if ( ! empty( $pg_id ) ) {
+			printf(
+				'<h3><a href="%1$s">%2$s</a></h3>',
+				get_permalink( $pg_id ),
+				wp_kses_post( __( $show_menu_title, 'inn' ) )
+			);
+			echo '<ul>';
+				wp_list_pages( 'title_li=&child_of=' . $pg_id . '&echo=1' );
 			echo '</ul>';
 		}
-	}
 
-	// close the menu div.
-	if ( ! empty( $show_menu ) ) {
+		// close the menu div.
 		echo '</div>';
-	}
 
-	// load the mobile-nav implementation of the above item: a <select> with <options>
-	largo_render_template(
-		'partials/internal',
-		'subnav-dropdown',
-		array( 
-			'ancestors' => $ancestors,
-			'show_menu_title' => $show_menu_title,
-			'show_menu' => $show_menu,
-			'pg_id' => $pg_id,
-		),
-	);
+		// load the mobile-nav implementation of the above item: a <select> with <options>
+		largo_render_template(
+			'partials/internal',
+			'subnav-dropdown',
+			array( 
+				'ancestors' => $ancestors,
+				'show_menu_title' => $show_menu_title,
+				'show_menu' => $show_menu,
+				'pg_id' => $pg_id,
+			),
+		);
+	}
 }
 
 

--- a/single-one-column.php
+++ b/single-one-column.php
@@ -104,6 +104,7 @@ if ( is_page() || is_singular( 'pauinn_project' ) ) {
 	}
 }
 
+// load the mobile-nav implementation of the above item: a <select> with <options>
 get_template_part( 'partials/internal-subnav-dropdown' );
 
 if ( is_page( 'press' ) || is_page( 'news' ) ) {


### PR DESCRIPTION
## Changes

- Deduplicates "should menu show here" logic by removing that logic from `partials/internal-subnav-dropdown.php`, and setting that partial up to draw from variables passed via [`largo_render_template()`](https://github.com/INN/largo/blob/v0.6.4/inc/helpers.php#L244)
- Adds new constant `INN_PARENT_PAGE_IDS` in `functions.php`, for containing an array of post IDs that should have this menu, and uses that for The Best of Nonprofit News 2019
- Adds a note about an eventual rewrite of this section

![Screen Shot 2019-10-29 at 18 32 56 ](https://user-images.githubusercontent.com/1754187/67814497-95576e80-fa7a-11e9-933c-bfa0e5acd2f5.png)
![Screen Shot 2019-10-29 at 18 33 05 ](https://user-images.githubusercontent.com/1754187/67814498-95576e80-fa7a-11e9-902f-f3af447f2de6.png)


## Why

To make the Best of Nonprofit News 2019 have a menu to display its child pages.

Resolves https://github.com/INN/inn/issues/114

## Questions

<!-- prompts for feedback from reviewers -->

