### PR TITLE
Add line break for new homepage image text

### DIFF
--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -1,7 +1,7 @@
 <?php
 	// CTA options
 	$headline = "INN Days 2020";
-	$blurb = "June 16 and 17, The Westin Hotel Old Town, Alexandria, Virginia";
+	$blurb = "June 16 and 17,<br/>The Westin Hotel Old Town, Alexandria, Virginia";
 	$button_text = "Learn more";
 	$button_link = "https://inn.org/inn-days-2020/";
 


### PR DESCRIPTION
## Changes

For INN/umbrella-inndev#141
- Adds a line break between the date and location in the new homepage text

![Screen Shot 2020-02-26 at 10 53 30 AM](https://user-images.githubusercontent.com/18353636/75362089-3d910e80-5886-11ea-8e24-ea61498e9468.png)

## Why

INN/umbrella-inndev#141