### PR TITLE
Frontend tweaks for GiveWP form updates

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -606,9 +606,9 @@ form[id*=give-form] #give-donation-level-radio-list > li label {
 #site-header a.btn {
   margin-left: 20px;
   margin-top: 24px;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.4;
-  padding: 8px;
+  padding: 12px;
   cursor: pointer;
 }
 #site-header .widget {

--- a/css/style.css
+++ b/css/style.css
@@ -539,6 +539,16 @@ form[id*=give-form] #give-donation-level-radio-list > li label {
   display: inline;
   font-size: 18px;
 }
+@min-width ( 781px ) {
+  .alignfull .wp-block-columns {
+    margin-bottom: 32px;
+    margin-top: 32px;
+  }
+}
+.alignfull .wp-block-columns {
+  margin-left: 32px;
+  margin-right: 32px;
+}
 .widget.rev {
   padding: 24px;
   border: 8px solid #0089bb;

--- a/css/style.css
+++ b/css/style.css
@@ -82,13 +82,19 @@ a:hover {
   color: #08bdff;
 }
 .btn,
+a.btn {
+  padding: 12px 24px;
+}
+.give-btn {
+  padding: 12px;
+}
+.btn,
 a.btn,
 .give-btn {
   text-shadow: none;
   border: none;
   text-transform: uppercase;
   font-weight: bold;
-  padding: 12px 24px;
   background-color: #0089bb;
   color: #fff;
   border-radius: 0;
@@ -533,9 +539,26 @@ form[id*=give-form] #give-donation-level-radio-list > li label {
   display: inline;
   font-size: 18px;
 }
+#sidebar .widget.rev {
+  padding: 24px;
+  border: 8px solid #0089bb;
+  font-family: "Merriweather", georgia, serif;
+  font-weight: 300;
+}
 .tribe-events-tooltip .entry-title {
   padding: 3px 6px 6px;
   font-size: 2em;
+}
+.give-form input[type="file"],
+.give-form select {
+  height: unset;
+}
+.give-submit.give-btn {
+  color: #fff;
+  background-color: #ff8b4d;
+}
+.give-submit.give-btn:hover {
+  background-color: #ff762d;
 }
 #header-social .icon-youtube-parent,
 #header-social .icon-gplus-parent,

--- a/css/style.css
+++ b/css/style.css
@@ -539,11 +539,25 @@ form[id*=give-form] #give-donation-level-radio-list > li label {
   display: inline;
   font-size: 18px;
 }
-#sidebar .widget.rev {
+.widget.rev {
   padding: 24px;
   border: 8px solid #0089bb;
   font-family: "Merriweather", georgia, serif;
   font-weight: 300;
+  color: inherit;
+  background-color: transparent;
+}
+.widget.rev .widgettitle {
+  background-color: transparent;
+  color: #005270;
+  padding: 0;
+}
+.widget.rev .widgettitle a {
+  color: #005270;
+}
+.widget.rev a {
+  color: #0089bb;
+  font-weight: normal;
 }
 .tribe-events-tooltip .entry-title {
   padding: 3px 6px 6px;

--- a/less/blocks.less
+++ b/less/blocks.less
@@ -1,0 +1,14 @@
+// Add whitespace to columns within fullwidth block
+// 781px matches Gutenberg's breakpoint where columns go from single-colum to multi-column
+// these styles assume that there won't be Fullwidth > * > Column setups
+// @link https://github.com/INN/umbrella-inndev/issues/159
+@min-width ( 781px ) {
+  .alignfull .wp-block-columns {
+    margin-bottom: 32px;
+    margin-top: 32px;
+  }
+}
+.alignfull .wp-block-columns {
+  margin-left: 32px;
+  margin-right: 32px;
+}

--- a/less/common.less
+++ b/less/common.less
@@ -50,12 +50,17 @@ a {
     color: @linkhover;
   }
 }
+.btn, a.btn {
+  padding: 12px 24px;
+}
+.give-btn {
+  padding: 12px;
+}
 .btn, a.btn, .give-btn {
   text-shadow: none;
   border: none;
   text-transform: uppercase;
   font-weight: bold;
-  padding: 12px 24px;
   background-color: @btnbg;
   color: #fff;
   border-radius: 0;

--- a/less/plugin-compat-give.less
+++ b/less/plugin-compat-give.less
@@ -1,0 +1,8 @@
+.give-form {
+  input[type="file"], select {
+    height: unset;
+  }
+}
+.give-submit.give-btn {
+  .give-btn.btn-primary();
+}

--- a/less/style.less
+++ b/less/style.less
@@ -14,7 +14,9 @@ Version:        0.2.0
 @import "utilities.less";
 @import "common.less";
 @import "forms.less";
+@import "widgets.less";
 @import "tribe-events.less";
+@import "plugin-compat-give.less";
 
 #header-social {
   .icon-youtube-parent,

--- a/less/style.less
+++ b/less/style.less
@@ -47,13 +47,14 @@ Version:        0.2.0
   img {
 	max-width: 280px;
   }
+
   a.btn {
-	margin-left: 20px;
-	margin-top: 24px;
-	font-size:12px;
-	line-height:1.4;
-	padding:8px;
-	cursor:pointer;
+    margin-left: 20px;
+    margin-top: 24px;
+    font-size: 14px;
+    line-height: 1.4;
+    padding: 12px;
+    cursor: pointer;
   }
   .widget {
 	margin-bottom: 0;

--- a/less/style.less
+++ b/less/style.less
@@ -14,6 +14,7 @@ Version:        0.2.0
 @import "utilities.less";
 @import "common.less";
 @import "forms.less";
+@import "blocks.less";
 @import "widgets.less";
 @import "tribe-events.less";
 @import "plugin-compat-give.less";

--- a/less/widgets.less
+++ b/less/widgets.less
@@ -1,6 +1,21 @@
-#sidebar .widget.rev {
+// Make the Reverse style be just a border around the plain Normal widget
+.widget.rev {
   padding: 24px;
   border: 8px solid @blue;
   font-family: @serif;
   font-weight: 300;
+  color: inherit;
+  background-color: transparent;
+  .widgettitle {
+    background-color: transparent;
+    color: @darkblue;
+    padding: 0;
+    a {
+      color: @darkblue;
+    }
+  }
+  a {
+    color: @blue;
+    font-weight: normal;
+  }
 }

--- a/less/widgets.less
+++ b/less/widgets.less
@@ -1,0 +1,6 @@
+#sidebar .widget.rev {
+  padding: 24px;
+  border: 8px solid @blue;
+  font-family: @serif;
+  font-weight: 300;
+}


### PR DESCRIPTION

## Changes

- Starts separate LESS files for widgets and GiveWP-specific styles
- Sets padding on GiveWP buttons from `12px 24px` to `12px`
- Makes the Give submit button match the `.btn-primary` styles
- Fixes `<select>` height when padded by Give's styles
- Gives widgets with the `.rev` "Reverse background" class a blue border
- Columns block margins as described in https://github.com/INN/umbrella-inndev/issues/159

<!-- relevant screenshot here -->
![Screenshot_2020-04-28 Institute for Nonprofit News](https://user-images.githubusercontent.com/1754187/80448749-4a17fe80-88eb-11ea-9877-bde5db2de68a.png)

## Why
For  https://github.com/INN/umbrella-inndev/issues/146 and https://github.com/INN/umbrella-inndev/issues/159

## Questions

- [ ] What other changes are necessary for the reverse widget styles?