### PR TITLE
umbrella-inndev 163: Homepage updates for INN Days

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,31 @@
 ## Changes
 
--
--
+This pull request makes the following changes:
+
+- <!-- what changed? -->
 
 <!-- relevant screenshot here -->
 
 ## Why
 
-<!-- who requested change, where? Is there a ticket URL or number for it? -->
+<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
+<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
+For #
 
-## Questions
+## Testing/Questions
 
-<!-- prompts for feedback from reviewers -->
+Features that this PR affects:
+
+-
+
+<!-- If there are no questions, please remove the questions section. -->
+Questions that need to be answered before merging:
+
+- [ ] Is this PR targeting the correct branch in this repository?
+- [ ] Is this deployed to staging? <!-- leave a comment below when done so -->
+- [ ]
+
+Steps to test this PR:
+
+1. <!-- list any configuration changes, settings, test content, or other things necessary to test this change. -->
 

--- a/archive-inn_member.php
+++ b/archive-inn_member.php
@@ -90,7 +90,6 @@ $states = array(
 					 *
 					 * Draws from the global query, which because of the pre_get_posts filter inn_member_archive_query contains <=500 INN members.
 					 * @since https://github.com/INN/inn/issues/73
-					 */
 					 global $wp_query;
 					if ( is_int( $wp_query->post_count ) && 0 < $wp_query->post_count ) {
 						echo (string) $wp_query->post_count;
@@ -98,6 +97,10 @@ $states = array(
 						echo '250+';
 						echo '<!-- check the logic here, something has gone wrong -->';
 					}
+					 */
+					 // per https://secure.helpscout.net/conversation/1193187834/5680/
+					 // fudging this to 250+ for now.
+					 echo '250+';
 				?>
 				members is a nonprofit, nonpartisan organization committed to editorial independence and transparency.</p>
 			</section>

--- a/archive-inn_member.php
+++ b/archive-inn_member.php
@@ -95,7 +95,7 @@ $states = array(
 					if ( is_int( $wp_query->post_count ) && 0 < $wp_query->post_count ) {
 						echo (string) $wp_query->post_count;
 					} else {
-						echo '170+';
+						echo '250+';
 						echo '<!-- check the logic here, something has gone wrong -->';
 					}
 				?>

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -107,7 +107,7 @@
 		<h3><span>About INN</span></h3>
 		<div class="row-fluid">
 			<div class="span12">
-				<h5>INN supports more than 200 nonprofit newsrooms across the U.S., working to strengthen the sources of trusted news for thousands of diverse communities.</h5>
+				<h5>INN strengthens and supports more than 250 independent news organizations in a new kind of media network: nonprofit, nonpartisan and dedicated to public service.</h5>
 			</div>
 		</div>
 		<div class="row-fluid">

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -224,32 +224,3 @@
 		</div>
 	</div>
 </section>
-
-<section id="supporters" class="interstitial">
-	<div class="content">
-		<h3>Thanks, Supporters!</h3>
-		<div class="row-fluid">
-			<ul class="span4">
-				<li><a href="https://www.craigslist.org/about/charitable">craigslist Charitable Fund</a></li>
-				<li><a href="http://democracyfund.org/">Democracy Fund</a></li>
-				<li><a href="http://www.journalismfoundation.org/default.asp">Ethics &amp; Excellence in Journalism Foundation</a></li>
-				<li><a href="https://www.fordfoundation.org/">Ford Foundation</a></li>
-				<li><a href="http://www.knightfoundation.org/">The John S. and James L. Knight Foundation</a></li>
-			</ul>
-			<ul class="span4">
-				<li><a href="http://www.macfound.org/">John D. &amp; Catherine T. MacArthur Foundation</a></li>
-				<li><a href="https://jonathanloganfamilyfoundation.org/">Jonathan Logan Family Foundation</a></li>
-				<li><a href="http://www.joycefdn.org/">Joyce Foundation</a></li>
-				<li><a href="http://www.mccormickfoundation.org/">Robert R. McCormick Foundation</a></li>
-				<li><a href="http://www.opensocietyfoundations.org/">Open Society Foundations</a></li>
-			</ul>
-			<ul class="span4">
-				<li>Park Foundation</li>
-				<li>Present Progressive Fund</li>
-				<li><a href="http://www.driehausfoundation.org/">Richard H. Driehaus Foundation</a></li>
-				<li><a href="http://rbf.org/">Rockefeller Brothers Fund</a></li>
-				<li><a href="/about/people/board-of-directors/">The INN Board</a></li>
-			</ul>
-		</div>
-	</div>
-</section>

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -119,7 +119,7 @@
 			<div class="span4">
 				<a href="/members/"><img class="icon" src="<?php echo $img_path . 'icons/memberdirectory.svg'; ?>" /></a>
 				<h5><a href="/members/">Our Members</a></h5>
-				<p>200+ nonprofits publishing news in the public interest</p>
+				<p>250+ nonprofits publishing news in the public interest</p>
 			</div>
 			<div class="span4">
 				<a href="/news/"><img class="icon" src="<?php echo $img_path . 'icons/news.svg'; ?>" /></a>

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -107,7 +107,7 @@
 		<h3><span>About INN</span></h3>
 		<div class="row-fluid">
 			<div class="span12">
-				<h5>INN is a network of more than 200 nonprofit newsrooms across the U.S., working to strengthen the sources of trusted news for thousands of diverse communities.</h5>
+				<h5>INN supports more than 200 nonprofit newsrooms across the U.S., working to strengthen the sources of trusted news for thousands of diverse communities.</h5>
 			</div>
 		</div>
 		<div class="row-fluid">


### PR DESCRIPTION
## Changes


- Changes the wording of the INN description to match that requested:
    ```diff
    - <h5>INN is a network of more than 200 nonprofit newsrooms across the U.S., working to  strengthen the sources of trusted news for thousands of diverse communities.</h5>
    + <h5>INN supports more than 200 nonprofit newsrooms across the U.S., working to strengthen the sources of trusted news for thousands of diverse communities.</h5>
    ```
- Updates other "200+" member counts to "250+"
- Fudges the member count on inn.org/members to "250+"
- Removes the "Thanks, Supporters!" section from the homepage
![Screenshot_2020-06-15 Institute for Nonprofit News - Supporting Mission-Driven Journalism](https://user-images.githubusercontent.com/1754187/84709636-8998b980-af30-11ea-8498-e5f345a926f5.png)


- Updates INN/inn PR template to cover what we cover in https://github.com/INN/.github/blob/master/PULL_REQUEST_TEMPLATE.md

## Why

For https://github.com/INN/umbrella-inndev/issues/163, by request of Sarah and approved by Sharene

## Testing/Questions

Features that this PR affects:

- the homepage

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [x] Is this deployed to staging?
- [ ] Did we remove the right section?
- [ ] Does the updated wording match the wording in https://secure.helpscout.net/conversation/1193187834/5680?folderId=1211651

Steps to test this PR:

1. view the homepage

