### PR TITLE
replace embedded MailChimp form with Customizer controls for headline, blurb, and button

### DIFF
--- a/homepages/homepage.php
+++ b/homepages/homepage.php
@@ -182,6 +182,96 @@ function inn_homepage_customize_image( $wp_customize ) {
 			'type' => 'url',
 		)
 	);
+
+	/*
+	 * Newsletter section
+	 */
+	$wp_customize->add_section( 'inn_homepage_newsletter', array(
+		'title' => __( 'INN Homepage Newsletter Section', 'inn' ),
+		'capability' => 'edit_theme_options',
+		'description' => __( 'Options for the Newsletter subscription area image on the homepage, and its text', 'inn' ),
+		'active_callback' => 'is_home',
+	) );
+
+	// Newsletter section header
+	$wp_customize->add_setting( 'inn_homepage_newsletter_headline', array(
+		'type' => 'theme_mod',
+		'capability' => 'edit_theme_options',
+		'default' => null,
+		'transport' => 'refresh',
+		'sanitize_callback' => 'sanitize_text_field',
+		'sanitize_js_callback' => '',
+	) );
+	// this saves a post ID
+	$wp_customize->add_control(
+		'inn_homepage_newsletter_headline',
+		array(
+			'label' => __( 'Label for Newsletter Section header', 'inn' ),
+			'description' => __( 'This text is shown at the top of the newsletter section.', 'inn' ),
+			'section' => 'inn_homepage_newsletter',
+			'type' => 'text',
+		)
+	);
+
+	// blurb text
+	$wp_customize->add_setting( 'inn_homepage_newsletter_blurb', array(
+		'type' => 'theme_mod',
+		'capability' => 'edit_theme_options',
+		'default' => null,
+		'transport' => 'refresh',
+		'sanitize_callback' => 'wp_kses_post',
+		'sanitize_js_callback' => '',
+	) );
+	$wp_customize->add_control(
+		'inn_homepage_newsletter_blurb',
+		array(
+			'label' => __( 'Newsletter Section Blurb', 'inn' ),
+			'description' => __( 'This text appears beneath the headline, but above the button. To break a paragraph into two, use an empty line.', 'inn' ),
+			'type' => 'textarea',
+			'section' => 'inn_homepage_newsletter',
+		)
+	);
+
+	// button text
+	$wp_customize->add_setting( 'inn_homepage_newsletter_button_text', array(
+		'type' => 'theme_mod',
+		'capability' => 'edit_theme_options',
+		'default' => null,
+		'transport' => 'refresh',
+		'sanitize_callback' => 'sanitize_text_field',
+		'sanitize_js_callback' => '',
+	) );
+	$wp_customize->add_control(
+		'inn_homepage_newsletter_button_text',
+		array(
+			'label' => __( 'Label for Newsletter Button', 'inn' ),
+			'description' => __( 'This text is shown on the button, which appears below the blurb text.', 'inn' ),
+			'section' => 'inn_homepage_newsletter',
+			'type' => 'text',
+		)
+	);
+
+	// button linke
+	$wp_customize->add_setting( 'inn_homepage_newsletter_button_link', array(
+		'type' => 'theme_mod',
+		'capability' => 'edit_theme_options',
+		'default' => null,
+		'transport' => 'refresh',
+		'sanitize_callback' => 'esc_url_raw',
+		'validate_callback' => 'inn_homepage_featured_link_validate',
+		'sanitize_js_callback' => '',
+	) );
+	$wp_customize->add_control(
+		'inn_homepage_newsletter_button_link',
+		array(
+			'label' => __( 'Featured Link', 'inn' ),
+			'description' => __( 'This link applies to the newsletter section button.', 'inn' ),
+			'section' => 'inn_homepage_newsletter',
+			'type' => 'url',
+		)
+	);
+
+
 }
 add_action( 'customize_register', 'inn_homepage_customize_image' );
 

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -164,7 +164,7 @@
 				$newsletter_button_link = esc_html( get_theme_mod( 'inn_homepage_newsletter_button_link' ) );
 				if ( ! empty( $newsletter_button_text ) ) {
 					printf(
-						'<div class="btn btn-primary" href="%1$s">%2$s</div>',
+						'<a class="btn btn-primary" href="%1$s">%2$s</a>',
 						esc_attr( $newsletter_button_link ),
 						$newsletter_button_text // esc_html'd earlier
 					);

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -151,18 +151,26 @@
 	<div class="content">
 		<img class="mail-icon" src="<?php echo $img_path . 'icons/mail-squares.png'; ?>" />
 		<div class="content-inner">
-			<h3>Stay Up To Date</h3>
-			<p>News from INN and our members. <strong>Delivered weekly.</strong></p>
+			<?php
+				
+				printf( 
+					'<h3>%1$s</h3>',
+					esc_html( get_theme_mod( 'inn_homepage_newsletter_headline' ) )
+				);
 
-			<!-- Begin Constant Contact Inline Form Code -->
-			<div class="ctct-inline-form" data-form-id="3616f3f6-cb66-46aa-ab4b-ed9191259019"></div>
-			<!-- End Constant Contact Inline Form Code -->
+				echo wp_kses_post( wpautop( get_theme_mod( 'inn_homepage_newsletter_blurb' ) ) );
 
-			<!-- Begin Constant Contact Active Forms -->
-			<script> var _ctct_m = "8822706d3cad02ed9d29ef563a1f2349"; </script>
-			<script id="signupScript" src="//static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js" async defer></script>
-			<!-- End Constant Contact Active Forms -->
+				$newsletter_button_text = esc_html( get_theme_mod( 'inn_homepage_newsletter_button_text' ) );
+				$newsletter_button_link = esc_html( get_theme_mod( 'inn_homepage_newsletter_button_link' ) );
+				if ( ! empty( $newsletter_button_text ) ) {
+					printf(
+						'<div class="btn btn-primary" href="%1$s">%2$s</div>',
+						esc_attr( $newsletter_button_link ),
+						$newsletter_button_text // esc_html'd earlier
+					);
+				}
 
+			?>
 		</div>
 	</div>
 </section>

--- a/homepages/templates/inn.php
+++ b/homepages/templates/inn.php
@@ -154,19 +154,15 @@
 			<h3>Stay Up To Date</h3>
 			<p>News from INN and our members. <strong>Delivered weekly.</strong></p>
 
-			<form action="//inn.us1.list-manage.com/subscribe/post?u=81670c9d1b5fbeba1c29f2865&amp;id=19bec3393e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-			    <div id="mc_embed_signup_scroll">
-					<div class="mc-field-group">
-						<input type="email" value="email address" name="EMAIL" class="required email" id="mce-EMAIL">
-					</div>
-					<div id="mce-responses" class="clear">
-						<div class="response" id="mce-error-response" style="display:none"></div>
-						<div class="response" id="mce-success-response" style="display:none"></div>
-					</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-				    <div style="position: absolute; left: -5000px;"><input type="text" name="b_81670c9d1b5fbeba1c29f2865_19bec3393e" tabindex="-1" value=""></div>
-				    <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn">
-				</div>
-			</form>
+			<!-- Begin Constant Contact Inline Form Code -->
+			<div class="ctct-inline-form" data-form-id="3616f3f6-cb66-46aa-ab4b-ed9191259019"></div>
+			<!-- End Constant Contact Inline Form Code -->
+
+			<!-- Begin Constant Contact Active Forms -->
+			<script> var _ctct_m = "8822706d3cad02ed9d29ef563a1f2349"; </script>
+			<script id="signupScript" src="//static.ctctcdn.com/js/signup-form-widget/current/signup-form-widget.min.js" async defer></script>
+			<!-- End Constant Contact Active Forms -->
+
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the homepage Mailchimp signup form; replaces it with a JS-powered Constant Contact one. The JS comes from Sarah's email in https://secure.helpscout.net/conversation/1213856192/5823?folderId=2730118#thread-3480078682

<!-- relevant screenshot here -->
![Screen Shot 2020-07-07 at 23 55 27](https://user-images.githubusercontent.com/1754187/86873937-5f5c9680-c0ad-11ea-9d07-494bb5c40c3c.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For https://github.com/INN/umbrella-inndev/issues/165#issuecomment-655135189 and https://secure.helpscout.net/conversation/1213856192/5823?folderId=2730118

## Testing/Questions

Features that this PR affects:

-

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] Is this deployed to staging? <!-- leave a comment below when done so -->
- [ ] How can styles be improved here?
- [ ] Are we concerned about what this form looks like if the subscribe form does not load? Does this need fallback content inside the `div`?

Steps to test this PR:

1. Visit the homepage of the INN site and scroll down to "Stay Up To Date" 

